### PR TITLE
Add entrypoints to requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pip
     - python >=3.5
   run:
+    - entrypoints
     - jupyter_core >=4.6.0
     - python >=3.5
     - python-dateutil >=2.1


### PR DESCRIPTION
This updates the conda recipe to include `entrypoints` as a dependency as that is new in the 7.0 release.  I didn't have permission to push directly, thus this PR.

Question: as best as I can determine (poking around other feedstocks), it seems the `entry_points` entries in `meta.yml` only pertain to `console_scripts`.  Is there a way (and is it necessary) to add entries for "custom" entrypoints (e.g., like [`jupyter_client.kernel_provisioners`](https://github.com/jupyter/jupyter_client/blob/be67c654ecd15f7ef6ca0db557f2d47f5b14e8d8/setup.py#L68))?

cc: @bollwyvl, @carreau, @davidbrochart